### PR TITLE
Updating assert in onNormalStateWrite

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -4619,7 +4619,7 @@ void Executor::onNormalStateWrite(
 
   uint64_t concreteAddress = dyn_cast<ConstantExpr>(address)->getZExtValue();
   size_t sizeInBytes = value->getWidth() / 8;
-  assert(sizeInBytes * 8 == value->getWidth());
+  assert(value->getWidth() == 1 || sizeInBytes * 8 == value->getWidth());
 
   /* TODO: don't add if already recovered */
   state.addWrittenAddress(concreteAddress, sizeInBytes, state.getCurrentSnapshotIndex());


### PR DESCRIPTION
The current assertion causes a crash when encountering a boolean expression (size 1). This is a valid scenario that should be supported, so I added an extra condition to the assertion.