### PR TITLE
Fix InterleavedSearcher::empty and InterleavedSearcher::selectState only checking the first searcher

### DIFF
--- a/lib/Core/Searcher.cpp
+++ b/lib/Core/Searcher.cpp
@@ -647,8 +647,12 @@ InterleavedSearcher::~InterleavedSearcher() {
 }
 
 ExecutionState &InterleavedSearcher::selectState() {
-  Searcher *s = searchers[--index];
-  if (index==0) index = searchers.size();
+  assert(!empty());
+  Searcher *s;
+  do {
+    s = searchers[--index];
+    if (index==0) index = searchers.size();
+  } while(s->empty());
   return s->selectState();
 }
 

--- a/lib/Core/Searcher.h
+++ b/lib/Core/Searcher.h
@@ -295,7 +295,13 @@ namespace klee {
     void update(ExecutionState *current,
                 const std::vector<ExecutionState *> &addedStates,
                 const std::vector<ExecutionState *> &removedStates);
-    bool empty() { return searchers[0]->empty(); }
+    bool empty() {
+      for (searchers_ty::iterator it = searchers.begin(), ie = searchers.end();
+           it != ie; ++it)
+        if(!(*it)->empty())
+          return false;
+      return true;
+    }
     void printName(llvm::raw_ostream &os) {
       os << "<InterleavedSearcher> containing "
          << searchers.size() << " searchers:\n";


### PR DESCRIPTION
Mirrors https://github.com/klee/klee/pull/1207.

This fixes a bug that causes some benchmarks to crash with `--split-search`. Example:

main.c
```c
#include <klee/klee.h>
#include <assert.h>

int global;
int a3 = 0;
void f3r() {
    global = a3;
}

void f3w() {
    a3 = 1;
}

int main(int argc, char *argv[]) {
    f3w(); // skip this
    f3r();

    assert(!global); // error at this line
    return 0;
}
```

```
$ kleegacy -libc=uclibc --split-search --skip-functions=f3w main.bc
KLEE: NOTE: Using klee-uclibc : /home/ubuntu/code/chopper/legacy_build/Release+Asserts/lib/klee-uclibc.bca
KLEE: output directory is "/home/ubuntu/code/chopper/examples/exrecovery/klee-out-8"
Using STP solver backend
KLEE: Runnining pointer analysis...
KLEE: Runnining reachability analysis...
KLEE: Runnining mod-ref analysis...
KLEE: WARNING: undefined reference to function: __crit_2_0
KLEE: WARNING: undefined reference to function: fcntl
KLEE: WARNING: undefined reference to function: fstat
KLEE: WARNING: undefined reference to function: ioctl
KLEE: WARNING: undefined reference to function: open
KLEE: WARNING ONCE: calling external: ioctl(0, 21505, 94642363638720)
KLEE: WARNING ONCE: calling __user_main with extra arguments.
kleegacy: /home/ubuntu/code/chopper/include/klee/Internal/ADT/DiscretePDF.inc:169: T klee::DiscretePDF<T>::choose(double) [with T = klee::ExecutionState*]: Assertion `0 && "choose: choose() called on empty tree"' failed.
```
