### PR TITLE
Bugfix: add field-insensitive information upon reaching a field-sensitive store

### DIFF
--- a/lib/Analysis/ModRefAnalysis.cpp
+++ b/lib/Analysis/ModRefAnalysis.cpp
@@ -181,6 +181,15 @@ void ModRefAnalysis::addStore(
             assert(false);
         }
 
+        // if nodeId is field-sensitive, add field-insensitive info too
+        bool insensitive = aa->getPTA()->getFIObjNode(nodeId) == nodeId;
+        if(!insensitive) {
+            NodeID FInodeId = aa->getPTA()->getFIObjNode(nodeId);
+            pair<Function *, NodeID> k = make_pair(f, FInodeId);
+            objToStoreMap[k].insert(store);
+            modPts.set(FInodeId);
+        }
+
         /* TODO: check static objects? */
         if (obj->getMemObj()->isStack()) {
             const Value *value = obj->getMemObj()->getRefVal();

--- a/test/Slicing/field-sensitivity-hetero.c
+++ b/test/Slicing/field-sensitivity-hetero.c
@@ -1,0 +1,32 @@
+// RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
+// RUN: rm -rf %t.klee-out
+// RUN: %klee --skip-functions=foo --output-dir=%t.klee-out %t1.bc > %t2.out 2> %t2.out
+// RUN: FileCheck %s -input-file=%t2.out
+// RUN: test ! -f %t.klee-out/test000001.ptr.err
+
+// CHECK: 1 (good!)
+// CHECK: recovery states = 2
+// CHECK-NOT: (bad!)
+
+#include <stdio.h>
+
+int off = 0;
+char* file = "12";
+
+void foo(char *x) {
+   x[0] = file[off++];
+}
+
+void bar(char* x) {
+   x[0] = file[off++];
+}
+
+int main(int argc, char** argv) {
+    char a, b;
+    foo(&a);
+    bar(&b);
+
+    if (a == '1')
+      printf("1 (good!)\n");
+    else printf("%d (bad!)\n", a);
+}


### PR DESCRIPTION
- 88b2a38 fixes the reduced `small.c` breaking example from https://gist.github.com/jordr/55817398f88255dedfe206dd8337dba1
- 1eb3f6f adds `small.c` as a unit test at `test/Slicing/field-sensitivity-hetero.c`. Without https://github.com/davidtr1037/chopper/commit/88b2a38fd85b32f7ee8eb5d27951273dcaecba61, this unit test fails
- this does not fix the original posix example from https://gist.github.com/jordr/55817398f88255dedfe206dd8337dba1